### PR TITLE
Refactor for VHDL libraries

### DIFF
--- a/rtl/BsaMpsMsgTxFramer.vhd
+++ b/rtl/BsaMpsMsgTxFramer.vhd
@@ -18,9 +18,13 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_unsigned.all;
 use ieee.std_logic_arith.all;
 
-use work.StdRtlPkg.all;
-use work.AxiStreamPkg.all;
-use work.SsiPkg.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.SsiPkg.all;
+
+library lcls2_llrf_bsa_mps_tx_core; 
 
 entity BsaMpsMsgTxFramer is
    generic (
@@ -87,7 +91,7 @@ begin
    ---------------------
    -- Data Packer Module
    ---------------------
-   U_Packer : entity work.BsaMpsMsgTxPacker
+   U_Packer : entity lcls2_llrf_bsa_mps_tx_core.BsaMpsMsgTxPacker
       generic map (
          TPD_G => TPD_G)
       port map (
@@ -216,7 +220,7 @@ begin
    --------------------
    -- CRC Engine
    --------------------
-   U_Crc32 : entity work.Crc32Parallel
+   U_Crc32 : entity surf.Crc32Parallel
       generic map (
          BYTE_WIDTH_G => 2)
       port map (

--- a/rtl/BsaMpsMsgTxGtx7.vhd
+++ b/rtl/BsaMpsMsgTxGtx7.vhd
@@ -18,7 +18,9 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_unsigned.all;
 use ieee.std_logic_arith.all;
 
-use work.StdRtlPkg.all;
+
+library surf;
+use surf.StdRtlPkg.all;
 
 library UNISIM;
 use UNISIM.VCOMPONENTS.all;
@@ -75,7 +77,7 @@ begin
       end if;
    end process;
 
-   U_Gtx7Core : entity work.Gtx7Core
+   U_Gtx7Core : entity surf.Gtx7Core
       generic map (
          -- SIM Generics
          TPD_G                    => TPD_G,

--- a/rtl/BsaMpsMsgTxPacker.vhd
+++ b/rtl/BsaMpsMsgTxPacker.vhd
@@ -18,9 +18,11 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_unsigned.all;
 use ieee.std_logic_arith.all;
 
-use work.StdRtlPkg.all;
-use work.AxiStreamPkg.all;
-use work.SsiPkg.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.SsiPkg.all;
 
 entity BsaMpsMsgTxPacker is
    generic (
@@ -243,7 +245,7 @@ begin
       end if;
    end process seq;
 
-   U_RstSync : entity work.RstSync
+   U_RstSync : entity surf.RstSync
       generic map (
          TPD_G => TPD_G)
       port map (
@@ -253,7 +255,7 @@ begin
 
    usrReset <= usrRst or txRstSync;
 
-   U_StoreThenForward : entity work.AxiStreamFifoV2
+   U_StoreThenForward : entity surf.AxiStreamFifoV2
       generic map (
          -- General Configurations
          TPD_G               => TPD_G,

--- a/rtl/BsaMspMsgTxCore.vhd
+++ b/rtl/BsaMspMsgTxCore.vhd
@@ -16,8 +16,12 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-use work.StdRtlPkg.all;
-use work.AxiStreamPkg.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+
+library lcls2_llrf_bsa_mps_tx_core; 
 
 entity BsaMspMsgTxCore is
    generic (
@@ -85,7 +89,7 @@ begin
    ------------
    -- TX Module
    ------------
-   U_Tx : entity work.BsaMpsMsgTxFramer
+   U_Tx : entity lcls2_llrf_bsa_mps_tx_core.BsaMpsMsgTxFramer
       generic map (
          TPD_G => TPD_G)
       port map (
@@ -129,7 +133,7 @@ begin
    -------------
    -- GTX Module
    -------------
-   U_Gtx : entity work.BsaMpsMsgTxGtx7
+   U_Gtx : entity lcls2_llrf_bsa_mps_tx_core.BsaMpsMsgTxGtx7
       generic map (
          TPD_G                 => TPD_G,
          CPLL_REFCLK_SEL_G     => CPLL_REFCLK_SEL_G,

--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -2,4 +2,4 @@
 source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 
 # Load Source Code
-loadSource -dir "$::DIR_PATH/rtl"
+loadSource -lib lcls2_llrf_bsa_mps_tx_core -dir "$::DIR_PATH/rtl"


### PR DESCRIPTION
This change refactors the code to expect [SURF](https://github.com/slaclab/surf) and  modules and packages to be in a `surf` VHDL library.

It also refactors the code to place it's own modules and packages in a `lcls2_llrf_bsa_mps_tx_core` library.

This PR can't be merged until the corresponding changes in `surf` are merged.
 - https://github.com/slaclab/surf/pull/541